### PR TITLE
Add fix for pred contracts wrong blame

### DIFF
--- a/src/__tests__/week8/pred_contracts.test.ts
+++ b/src/__tests__/week8/pred_contracts.test.ts
@@ -5,7 +5,7 @@ test('contract violation on assignment', () => {
   const res = runTest(`let gt0 : int -> bool = fun (x : int) : bool -> x > 0;;
 contract f = gt0;;
 let f : int = -1;;`);
-  expectContractViolation(res, 'f', 2, 0); // contract definition location
+  expectContractViolation(res, 'main', 2, 0); // contract definition location
 });
 
 test('no contract violation if satisfy contract', () => {
@@ -24,7 +24,7 @@ test('contract violation on complex expression', () => {
   const res = runTest(`let gt0 : int -> bool = fun (x : int) : bool -> x > 0;;
 contract f = gt0;;
 let f : int = if false then 1 + 3 else (-1) - 100;;`);
-  expectContractViolation(res, 'f', 2, 0); // contract definition location
+  expectContractViolation(res, 'main', 2, 0); // contract definition location
 });
 
 test('no contract violation on complex expression if satisfy contract', () => {
@@ -49,5 +49,45 @@ let f : int = if true then 1 + 3 else (-1) - 100;;`);
     value: 4,
     type: intType,
     name: 'f',
+  });
+});
+
+test('contract violation in let local binding LHS', () => {
+  const res =
+    runTest(`let gt (x : int) : int -> bool = fun (y : int) : bool -> y > x;;
+contract f = (gt 0);;
+let f : int = 0 in f + 1;;`);
+  expectContractViolation(res, 'main', 2, 0); // contract definition location
+});
+
+test('no contract violation in let local binding LHS', () => {
+  const res =
+    runTest(`let gt (x : int) : int -> bool = fun (y : int) : bool -> y > x;;
+contract f = (gt 0);;
+let f : int = 1 in f + 1;;`);
+  expect(res).toEqual({
+    status: 'finished',
+    value: 2,
+    type: intType,
+  });
+});
+
+test('contract violation in let local binding RHS', () => {
+  const res =
+    runTest(`let gt (x : int) : int -> bool = fun (y : int) : bool -> y > x;;
+contract f = (gt 0);;
+let x : int = 0 in let f : int = 0 in 5;;`);
+  expectContractViolation(res, 'main', 2, 0); // contract definition location
+});
+
+test('no contract violation in let local binding RHS', () => {
+  const res =
+    runTest(`let gt (x : int) : int -> bool = fun (y : int) : bool -> y > x;;
+contract f = (gt 0);;
+let x : int = 0 in let f : int = 1 in 5;;`);
+  expect(res).toEqual({
+    status: 'finished',
+    value: 5,
+    type: intType,
   });
 });

--- a/src/contracts/runtime/checkGlobalLetContract.ts
+++ b/src/contracts/runtime/checkGlobalLetContract.ts
@@ -18,5 +18,5 @@ export function checkGlobalLetContract(
   if (contract == null || contract.type !== 'FlatContract') {
     return;
   }
-  checkFlatContract(node, result, contract, context, node.left.name);
+  checkFlatContract(node, result, contract, context, node.left.neg as string);
 }

--- a/src/contracts/static/contractMonitor.ts
+++ b/src/contracts/static/contractMonitor.ts
@@ -45,6 +45,7 @@ function monitorNode(node: Node, context: Context): void {
       break;
     }
     case 'LocalLetExpression': {
+      monitorNode(node.left, context);
       monitorNode(node.right, context);
       break;
     }
@@ -54,6 +55,7 @@ function monitorNode(node: Node, context: Context): void {
       break;
     }
     case 'GlobalLetStatement': {
+      monitorNode(node.left, context);
       pushContractEnvironment(context, {
         contractMap: new Map<string, Contract>(),
         currentScope: node.left.name,


### PR DESCRIPTION
Found bug while writing docs for pred contracts:

Case 1: Let local binding
```
let gt0 (x : int) : bool = x > 0;;
contract x = gt0;;
let x : int = 0 in x + 2;;
```


Case 2: Let global binding
```
let gt0 (x : int) : bool = x > 0;;
contract x = gt0;;
let x : int = 0;;
```
In both cases, should blame `main` but currently blaming `x`.

Added fix in contractMonitor and some tests.